### PR TITLE
Add missing resume fix which allows xpad mode to work after sleep

### DIFF
--- a/hid-msi-claw.c
+++ b/hid-msi-claw.c
@@ -408,6 +408,11 @@ static void msi_claw_remove(struct hid_device *hdev)
 	hid_hw_stop(hdev);
 }
 
+static int msi_claw_resume(struct hid_device *hdev)
+{
+	return msi_claw_probe(hdev, NULL);// re-apply xpad mode on resume
+}
+
 static const struct hid_device_id msi_claw_devices[] = {
 	{ HID_USB_DEVICE(0x0DB0, 0x1901) },
 	{ }
@@ -419,6 +424,7 @@ static struct hid_driver msi_claw_driver = {
 	.id_table		= msi_claw_devices,
 	.probe			= msi_claw_probe,
 	.remove			= msi_claw_remove,
+	.resume         = msi_claw_resume,
 	//.input_mapping	= msi_claw_input_mapping,
 	//.event		= msi_claw_event,
 	//.raw_event		= msi_claw_raw_event

--- a/hid-msi-claw.c
+++ b/hid-msi-claw.c
@@ -308,7 +308,7 @@ static ssize_t debug_read_show(struct device *dev, struct device_attribute *attr
 }
 static DEVICE_ATTR_RO(debug_read);
 
-static int msi_claw_probe(struct hid_device *hdev, const struct hid_device_id *id)
+static int msi_claw_enable_xpad_mode(struct hid_device *hdev)
 {
 	int ret;
 	struct msi_claw_drvdata *drvdata;
@@ -393,6 +393,11 @@ err_stop_hw:
 	return ret;
 }
 
+static int msi_claw_probe(struct hid_device *hdev, const struct hid_device_id *id)
+{
+	return msi_claw_enable_xpad_mode(hdev);
+}
+
 static void msi_claw_remove(struct hid_device *hdev)
 {
 	struct msi_claw_drvdata *drvdata = hid_get_drvdata(hdev);
@@ -410,7 +415,8 @@ static void msi_claw_remove(struct hid_device *hdev)
 
 static int msi_claw_resume(struct hid_device *hdev)
 {
-	return msi_claw_probe(hdev, NULL);// re-apply xpad mode on resume
+	sleep(1);// give the hardware a second to wake up
+	return msi_claw_enable_xpad_mode(hdev);// re-apply xpad mode on resume
 }
 
 static const struct hid_device_id msi_claw_devices[] = {


### PR DESCRIPTION
Looks like SteamOS is already including this driver.
From a user on ChimeraOS it looks like resume after sleep fix was not added.